### PR TITLE
Use custom property from site for font-color

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -1,7 +1,7 @@
 @import 'vars';
 
 @mixin font-color() {
-  color: #000; // fallback
+  color: #000000; // fallback
   color: $font-color;
 }
 

--- a/scss/vars.scss
+++ b/scss/vars.scss
@@ -1,9 +1,9 @@
-@import "sophie-color/vars/general.json";
-
 $font-family-sans: nzz-sans-serif, Helvetica, Arial;
 $font-family-serif: nzz-serif, Georgia;
 
-$font-color: var(--black);
+// --q-primary-text-color is defined in nzzdev/sophie-q
+// .s-q-item
+$font-color: var(--q-primary-text-color, #000000);
 
 $font-weight-serif-regular: 100;
 $font-weight-serif-bold: 500;


### PR DESCRIPTION
Currently experimental, will require discussion with Web IT. 

nzz.ch still uses `var(--black)` to define the text color – which makes not that much sense in a post-dark-mode-introduction world. 

magazin.nzz.ch has started using `var(--articleTextColor)`, but this is currently not available on nzz.ch.

Either way, the color defined as `s-color-gray-9` is no longer in use on nzz.ch.