### PR TITLE
fix: simplify `:not(:has(.font-sans))` selectors and update snapshots

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -9,11 +9,7 @@
   font-family: $font-family-serif;
   font-weight: $font-weight-serif-regular;
   @include font-color;
-
-	:not(:has(.font-sans)) & {
-		//we're in nuxt territory
-		font-weight: $font-weight-serif-nuxt-regular;
-	}
+	@include nuxt-fallback($font-weight-serif-nuxt-regular);
 }
 
 .s-font-text-s {
@@ -40,11 +36,7 @@
   font-family: $font-family-sans;
   font-weight: $font-weight-sans-regular;
 	@include font-color;
-
-	:not(:has(.font-sans)) & {
-		//we're in nuxt territory
-		font-weight: $font-weight-sans-nuxt-regular;
-	}
+	@include nuxt-fallback($font-weight-sans-nuxt-regular);
 
   &--strong {
     font-weight: $font-weight-sans-bold;
@@ -52,11 +44,7 @@
 
   &--light {
     font-weight: $font-weight-sans-light;
-
-	  :not(:has(.font-sans)) & {
-			//we're in nuxt territory
-			font-weight: $font-weight-sans-nuxt-light;
-		}
+	  @include nuxt-fallback($font-weight-sans-nuxt-light);
   }
 
   // Use to enable fixed-width numerals for charts and tables
@@ -106,20 +94,14 @@
   font-family: $font-family-serif;
   font-weight: $font-weight-serif-regular;
 
-	:not(:has(.font-sans)) & {
-		//we're in nuxt territory
-		font-weight: $font-weight-serif-nuxt-regular;
-	}
+	@include nuxt-fallback($font-weight-serif-nuxt-regular);
 }
 
 .s-font-sans {
   font-family: $font-family-sans;
   font-weight: $font-weight-sans-regular;
 
-	:not(:has(.font-sans)) & {
-		//we're in nuxt territory
-		font-weight: $font-weight-sans-nuxt-regular;
-	}
+	@include nuxt-fallback($font-weight-sans-nuxt-regular);
 }
 
 .s-font-ui {

--- a/scss/vars.scss
+++ b/scss/vars.scss
@@ -42,3 +42,15 @@ $font-ui-line-height: 1.5rem; // This translates to 24px
 
 $font-ui-s-size: 0.875rem; // This would correspondent to 14px
 $font-ui-s-line-height: 1.375rem; // This would correspondent to 22px
+
+// Provides fallback values for all cases where we depend on the old @font-face definitions.
+// @todo Replace once the old webview has been retired.
+@mixin nuxt-fallback($font-weight) {
+		:is(
+			#__nzz #__layout, /* nuxt IDs, should avoid the performance penalty of :not(:has()) */
+			#webviev, /* Webview ID */
+			:not(:has(.font-sans)) /* Fallback for Q editor and print export */
+		) & {
+		font-weight: $font-weight;
+	}
+}

--- a/test/__snapshots__/sass.css
+++ b/test/__snapshots__/sass.css
@@ -7,7 +7,9 @@
   color: #000000;
   color: var(--q-primary-text-color, #000000);
 }
-:not(:has(.font-sans)) .s-font-text-s {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-text-s {
   font-weight: 300;
 }
 .s-font-text-s--strong {
@@ -22,7 +24,9 @@
   color: #000000;
   color: var(--q-primary-text-color, #000000);
 }
-:not(:has(.font-sans)) .s-font-text {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-text {
   font-weight: 300;
 }
 .s-font-text--strong {
@@ -37,7 +41,9 @@
   color: #000000;
   color: var(--q-primary-text-color, #000000);
 }
-:not(:has(.font-sans)) .s-font-note-s {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-note-s {
   font-weight: 100;
 }
 .s-font-note-s--strong {
@@ -46,7 +52,9 @@
 .s-font-note-s--light {
   font-weight: 300;
 }
-:not(:has(.font-sans)) .s-font-note-s--light {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-note-s--light {
   font-weight: 50;
 }
 .s-font-note-s--tabularnums {
@@ -62,7 +70,9 @@
   color: #000000;
   color: var(--q-primary-text-color, #000000);
 }
-:not(:has(.font-sans)) .s-font-note {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-note {
   font-weight: 100;
 }
 .s-font-note--strong {
@@ -71,7 +81,9 @@
 .s-font-note--light {
   font-weight: 300;
 }
-:not(:has(.font-sans)) .s-font-note--light {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-note--light {
   font-weight: 50;
 }
 .s-font-note--tabularnums {
@@ -110,7 +122,9 @@
   font-family: nzz-serif, var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-weight: 400;
 }
-:not(:has(.font-sans)) .s-font-serif {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-serif {
   font-weight: 300;
 }
 
@@ -118,7 +132,9 @@
   font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 400;
 }
-:not(:has(.font-sans)) .s-font-sans {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-sans {
   font-weight: 100;
 }
 
@@ -130,7 +146,9 @@
   color: #000000;
   color: var(--q-primary-text-color, #000000);
 }
-:not(:has(.font-sans)) .s-font-ui {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-ui {
   font-weight: 100;
 }
 .s-font-ui--strong {
@@ -139,7 +157,9 @@
 .s-font-ui--light {
   font-weight: 300;
 }
-:not(:has(.font-sans)) .s-font-ui--light {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-ui--light {
   font-weight: 50;
 }
 .s-font-ui--tabularnums {
@@ -155,7 +175,9 @@
   color: #000000;
   color: var(--q-primary-text-color, #000000);
 }
-:not(:has(.font-sans)) .s-font-ui-s {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-ui-s {
   font-weight: 100;
 }
 .s-font-ui-s--strong {
@@ -164,7 +186,9 @@
 .s-font-ui-s--light {
   font-weight: 300;
 }
-:not(:has(.font-sans)) .s-font-ui-s--light {
+:is(#__nzz #__layout,
+#webviev,
+:not(:has(.font-sans))) .s-font-ui-s--light {
   font-weight: 50;
 }
 .s-font-ui-s--tabularnums {


### PR DESCRIPTION
For some reason, prepending it with `:root` would work with the sans-serif font, but not the serif one?