### PR TITLE
feat: add layered font family name declarations

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -1,117 +1,137 @@
 @import 'vars';
 
+@layer nuxt-fallback, q-custom-code-support;
+
+@layer nuxt-fallback {
+	/* use a layer to define the custom property */
+	/* This way the "unlayered" property will take precedence if available */
+	:root {
+		--nzz-font-sans: nzz-sans-serif;
+		--nzz-font-serif: nzz-serif;
+		--nzz-font-serif-alt: nzz-serif-alt;
+	}
+}
+
+@layer q-custom-code-support {
+	:root {
+		--font-family-sans: #{$font-family-sans};
+		--font-family-serif: #{$font-family-serif};
+		--font-family-serif-alt: #{$font-family-serif-alt};
+	}
+}
+
 @mixin font-color() {
-  color: #000000; // fallback
-  color: $font-color;
+	color: #000000; // fallback
+	color: $font-color;
 }
 
 @mixin s-font-text() {
-  font-family: $font-family-serif;
-  font-weight: $font-weight-serif-regular;
-  @include font-color;
+	font-family: $font-family-serif;
+	font-weight: $font-weight-serif-regular;
+	@include font-color;
 	@include nuxt-fallback($font-weight-serif-nuxt-regular, '--nzz-font-serif');
 }
 
 .s-font-text-s {
-  line-height: $font-text-s-line-height;
-  font-size: $font-text-s-size;
-  @include s-font-text;
+	line-height: $font-text-s-line-height;
+	font-size: $font-text-s-size;
+	@include s-font-text;
 
-  &--strong {
-    font-weight: $font-weight-serif-bold;
-  }
+	&--strong {
+		font-weight: $font-weight-serif-bold;
+	}
 }
 
 .s-font-text {
-  font-size: $font-text-size;
-  line-height: $font-text-line-height;
-  @include s-font-text;
+	font-size: $font-text-size;
+	line-height: $font-text-line-height;
+	@include s-font-text;
 
-  &--strong {
-    font-weight: $font-weight-serif-bold;
-  }
+	&--strong {
+		font-weight: $font-weight-serif-bold;
+	}
 }
 
 @mixin s-font-note() {
-  font-family: $font-family-sans;
-  font-weight: $font-weight-sans-regular;
+	font-family: $font-family-sans;
+	font-weight: $font-weight-sans-regular;
 	@include font-color;
 	@include nuxt-fallback($font-weight-sans-nuxt-regular);
 
-  &--strong {
-    font-weight: $font-weight-sans-bold;
-  }
+	&--strong {
+		font-weight: $font-weight-sans-bold;
+	}
 
-  &--light {
-    font-weight: $font-weight-sans-light;
-	  @include nuxt-fallback($font-weight-sans-nuxt-light);
-  }
+	&--light {
+		font-weight: $font-weight-sans-light;
+		@include nuxt-fallback($font-weight-sans-nuxt-light);
+	}
 
-  // Use to enable fixed-width numerals for charts and tables
-  &--tabularnums {
-    font-feature-settings: 'tnum' 1; // Fallback for IE11
-    font-variant-numeric: tabular-nums; // Modern browsers
-  }
+	// Use to enable fixed-width numerals for charts and tables
+	&--tabularnums {
+		font-feature-settings: 'tnum' 1; // Fallback for IE11
+		font-variant-numeric: tabular-nums; // Modern browsers
+	}
 }
 
 .s-font-note-s {
-  font-size: $font-note-s-size;
-  line-height: $font-note-s-line-height;
-  @include s-font-note;
+	font-size: $font-note-s-size;
+	line-height: $font-note-s-line-height;
+	@include s-font-note;
 }
 
 .s-font-note {
-  font-size: $font-note-size;
-  line-height: $font-note-line-height;
-  @include s-font-note;
+	font-size: $font-note-size;
+	line-height: $font-note-line-height;
+	@include s-font-note;
 }
 
 @mixin s-font-title() {
-  font-family: $font-family-sans;
-  font-weight: $font-weight-sans-bold;
-  @include font-color;
+	font-family: $font-family-sans;
+	font-weight: $font-weight-sans-bold;
+	@include font-color;
 }
 
 .s-font-title-s {
-  @include s-font-title;
-  font-size: $font-title-s-size;
-  line-height: $font-title-s-line-height;
+	@include s-font-title;
+	font-size: $font-title-s-size;
+	line-height: $font-title-s-line-height;
 }
 
 .s-font-title {
-  @include s-font-title;
-  font-size: $font-title-size;
-  line-height: $font-title-line-height;
+	@include s-font-title;
+	font-size: $font-title-size;
+	line-height: $font-title-line-height;
 }
 
 .s-font-title-l {
-  @include s-font-title;
-  font-size: $font-title-l-size;
-  line-height: $font-title-l-line-height;
+	@include s-font-title;
+	font-size: $font-title-l-size;
+	line-height: $font-title-l-line-height;
 }
 
 .s-font-serif {
-  font-family: $font-family-serif;
-  font-weight: $font-weight-serif-regular;
+	font-family: $font-family-serif;
+	font-weight: $font-weight-serif-regular;
 
 	@include nuxt-fallback($font-weight-serif-nuxt-regular, '--nzz-font-serif');
 }
 
 .s-font-sans {
-  font-family: $font-family-sans;
-  font-weight: $font-weight-sans-regular;
+	font-family: $font-family-sans;
+	font-weight: $font-weight-sans-regular;
 
 	@include nuxt-fallback($font-weight-sans-nuxt-regular);
 }
 
 .s-font-ui {
-  font-size: $font-ui-size;
-  line-height: $font-ui-line-height;
-  @include s-font-note;
+	font-size: $font-ui-size;
+	line-height: $font-ui-line-height;
+	@include s-font-note;
 }
 
 .s-font-ui-s {
-  font-size: $font-ui-s-size;
-  line-height: $font-ui-s-line-height;
-  @include s-font-note;
+	font-size: $font-ui-s-size;
+	line-height: $font-ui-s-line-height;
+	@include s-font-note;
 }

--- a/scss/vars.scss
+++ b/scss/vars.scss
@@ -1,5 +1,6 @@
-$font-family-sans:  nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
-$font-family-serif: nzz-serif, var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-family-sans:  var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+$font-family-serif: var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-family-serif-alt: var(--nzz-font-serif-alt, "NZZ Serif Alt"),"Iowan Old Style","Apple Garamond",Baskerville,"Times New Roman","Droid Serif",Times,"Source Serif Pro",serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
 
 // --q-primary-text-color is defined in nzzdev/sophie-q
 // .s-q-item

--- a/test/__snapshots__/sass.css
+++ b/test/__snapshots__/sass.css
@@ -1,8 +1,25 @@
 /* fonts.scss */
+@layer nuxt-fallback, q-custom-code-support;
+@layer nuxt-fallback {
+  /* use a layer to define the custom property */
+  /* This way the "unlayered" property will take precedence if available */
+  :root {
+    --nzz-font-sans: nzz-sans-serif;
+    --nzz-font-serif: nzz-serif;
+    --nzz-font-serif-alt: nzz-serif-alt;
+  }
+}
+@layer q-custom-code-support {
+  :root {
+    --font-family-sans: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+    --font-family-serif: var(--nzz-font-serif, "NZZ Serif"), Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+    --font-family-serif-alt: var(--nzz-font-serif-alt, "NZZ Serif Alt"), Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  }
+}
 .s-font-text-s {
   line-height: 28px;
   font-size: 18px;
-  font-family: nzz-serif, var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-weight: 400;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -17,7 +34,7 @@
 .s-font-text {
   font-size: 20px;
   line-height: 32px;
-  font-family: nzz-serif, var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-weight: 400;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -32,7 +49,7 @@
 .s-font-note-s {
   font-size: 12px;
   line-height: 16px;
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 400;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -57,7 +74,7 @@
 .s-font-note {
   font-size: 14px;
   line-height: 20px;
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 400;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -80,7 +97,7 @@
 }
 
 .s-font-title-s {
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 500;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -89,7 +106,7 @@
 }
 
 .s-font-title {
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 500;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -98,7 +115,7 @@
 }
 
 .s-font-title-l {
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 500;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -107,7 +124,7 @@
 }
 
 .s-font-serif {
-  font-family: nzz-serif, var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: var(--nzz-font-serif, "NZZ Serif"), "Iowan Old Style", "Apple Garamond", Baskerville, "Times New Roman", "Droid Serif", Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-weight: 400;
 }
 .s-font-serif:not(.--nzz-font-serif .s-font-serif) {
@@ -115,7 +132,7 @@
 }
 
 .s-font-sans {
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 400;
 }
 .s-font-sans:not(.--nzz-font-sans .s-font-sans) {
@@ -125,7 +142,7 @@
 .s-font-ui {
   font-size: 1rem;
   line-height: 1.5rem;
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 400;
   color: #000000;
   color: var(--q-primary-text-color, #000000);
@@ -150,7 +167,7 @@
 .s-font-ui-s {
   font-size: 0.875rem;
   line-height: 1.375rem;
-  font-family: nzz-sans-serif, var(--nzz-font-sans, "NZZ Sans"), -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+  font-family: var(--nzz-font-sans, "NZZ Sans"), system-ui, -apple-system, BlinkMacSystemFont, "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   font-weight: 400;
   color: #000000;
   color: var(--q-primary-text-color, #000000);


### PR DESCRIPTION
NEXT uses custom properties for the font names. We can leverage this, and add the same variable names in our own CSS cascade layer as a fallback for the NUXT version.

Refs: EDTECH-1703